### PR TITLE
Treat the environment during webpack build as browser rather than node

### DIFF
--- a/mockServerClient.js
+++ b/mockServerClient.js
@@ -10,6 +10,10 @@ var mockServerClient;
 (function () {
     "use strict";
 
+    runningInNode = function () {
+        return (typeof require !== 'undefined') && require('browser-or-node').isNode
+    }
+
     /**
      * Start the client communicating at the specified host and port
      * for example:
@@ -24,7 +28,7 @@ var mockServerClient;
      */
     mockServerClient = function (host, port, contextPath, tls, caCertPemFilePath) {
 
-        var makeRequest = (typeof require !== 'undefined' ? require('./sendRequest').sendRequest(tls, caCertPemFilePath) : function (host, port, path, jsonBody, resolveCallback) {
+        var makeRequest = (runningInNode() ? require('./sendRequest').sendRequest(tls, caCertPemFilePath) : function (host, port, path, jsonBody, resolveCallback) {
             var body = (typeof jsonBody === "string" ? jsonBody : JSON.stringify(jsonBody || ""));
             var url = (tls ? 'https' : 'http') + '://' + host + ':' + port + path;
 
@@ -171,7 +175,7 @@ var mockServerClient;
             };
         };
 
-        var WebSocketClient = (typeof require !== 'undefined' ? require('./webSocketClient').webSocketClient(tls, caCertPemFilePath) : function (host, port, contextPath) {
+        var WebSocketClient = (runningInNode() ? require('./webSocketClient').webSocketClient(tls, caCertPemFilePath) : function (host, port, contextPath) {
             var clientId;
             var clientIdHandler;
             var requestHandler;

--- a/package-lock.json
+++ b/package-lock.json
@@ -528,6 +528,11 @@
         }
       }
     },
+    "browser-or-node": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-1.3.0.tgz",
+      "integrity": "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg=="
+    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gruntplugin"
   ],
   "dependencies": {
+    "browser-or-node": "^1.3.0",
     "grunt-ts": "^6.0.0-beta.22",
     "q": "~2.0",
     "websocket": "^1.0.30"


### PR DESCRIPTION
Fixes #47

I need some help to set up tests for this. I was unable to run the tests locally, since on my local machine, I have installed neither grunt nor python (required for the npm package sleep, which is an optional dependency of karma-xvfb-chrome-launcher) nor java (required for mockserver) nor Chrome (I am running on Ubuntu). Rather, I use all those only in Docker containers when necessary.

I think a useful testing setup would require a new grunt task, like the ones you have set up for node and browser modes. We could take the easy way out and just copy the browser tests and define a global `require` mock before the tests. Or we could do it the completely correct way and somehow set up a Webpack environment within the tests, similar to how you start an entire browser for the browser tests. Both of these options go a little far given the superficial knowledge I have about this package's structure and build process.