### PR TITLE
Export types from mockserver client

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,3 +7,14 @@
  */
 
 export { mockServerClient } from './mockServerClient';
+export {
+  Expectation,
+  ExpectationId,
+  HttpRequest,
+  HttpResponse,
+  KeysToMultiValues,
+  OpenAPIExpectation,
+  RequestDefinition,
+  Times,
+  TimeToLive,
+} from  './mockServer';


### PR DESCRIPTION
In some projects the eslint rule import/no-unresolved is triggered when using the types from mock server client. We need to expose it in order to not face this issue.

some people use the rule below because of this
'import/no-unresolved': ['error', { ignore: ['mockserver-client/mockServer'] }]

This PR fix it