### PR TITLE
Add forwardWithCallback

### DIFF
--- a/mockServer.d.ts
+++ b/mockServer.d.ts
@@ -309,8 +309,8 @@ export interface Ports {
  * verification sequence
  */
 export type HttpRequestAndHttpResponse = {
-    httpRequest?: HttpRequest[];
-    httpResponse?: HttpResponse[];
+    httpRequest?: HttpRequest;
+    httpResponse?: HttpResponse;
     timestamp?: string;
 };
 

--- a/mockServerClient.d.ts
+++ b/mockServerClient.d.ts
@@ -69,7 +69,7 @@ export interface MockServerClient {
     forwardWithCallback(
         requestMatcher: RequestDefinition, 
         requestHandler: (request: HttpRequest) => HttpResponse, 
-        requestAndResponseHandler: (request: HttpRequestAndHttpResponse) => HttpResponse, 
+        requestAndResponseHandler: (requestAndResponse: HttpRequestAndHttpResponse) => HttpResponse, 
         times?: Times | number,
         priority?: number,
         timeToLive?: TimeToLive,

--- a/mockServerClient.d.ts
+++ b/mockServerClient.d.ts
@@ -29,6 +29,23 @@ export type RequestResponse = SuccessFullRequest | string;
 
 export type PathOrRequestDefinition = string | Expectation | RequestDefinition | undefined | null;
 
+export type ModifiableHttpRequest = Omit<HttpRequest, "headers"> & {
+  headers: { [key: string]: string[] };
+};
+
+export type ModifiableHttpResponse = Omit<HttpResponse, "headers"> & {
+  headers: { [key: string]: string[] };
+};
+
+export type HttpRequestCallbackHandler = (
+  request: ModifiableHttpRequest
+) => ModifiableHttpRequest;
+
+export type HttpRequestResponseCallbackHandler = ({
+  httpRequest: ModifiableHttpRequest,
+  httpResponse: ModifiableHttpResponse,
+}) => ModifiableHttpResponse;
+
 export interface MockServerClient {
     openAPIExpectation(expectation: OpenAPIExpectation): Promise<RequestResponse>;
 
@@ -68,8 +85,8 @@ export interface MockServerClient {
 
     forwardWithCallback(
         requestMatcher: RequestDefinition, 
-        requestHandler: (request: HttpRequest) => HttpResponse, 
-        requestAndResponseHandler: (requestAndResponse: HttpRequestAndHttpResponse) => HttpResponse, 
+        requestHandler: HttpRequestCallbackHandler, 
+        requestAndResponseHandler: HttpRequestResponseCallbackHandler, 
         times?: Times | number,
         priority?: number,
         timeToLive?: TimeToLive,

--- a/mockServerClient.d.ts
+++ b/mockServerClient.d.ts
@@ -44,7 +44,7 @@ export type HttpRequestCallbackHandler = (
 export type HttpRequestResponseCallbackHandler = ({
   httpRequest: ModifiableHttpRequest,
   httpResponse: ModifiableHttpResponse,
-}) => ModifiableHttpResponse;
+}) => ModifiableHttpResponse; 
 
 export interface MockServerClient {
     openAPIExpectation(expectation: OpenAPIExpectation): Promise<RequestResponse>;
@@ -69,7 +69,7 @@ export interface MockServerClient {
 
     clear(pathOrRequestDefinition: PathOrRequestDefinition, type: ClearType): Promise<RequestResponse>;
 
-    clearById(expectationId: ExpectationId, type: ClearType): Promise<RequestResponse>;
+    clearById(expectationId: string, type: ClearType): Promise<RequestResponse>;
 
     bind(ports: Port[]): Promise<RequestResponse>;
 

--- a/mockServerClient.d.ts
+++ b/mockServerClient.d.ts
@@ -41,10 +41,14 @@ export type HttpRequestCallbackHandler = (
   request: ModifiableHttpRequest
 ) => ModifiableHttpRequest;
 
-export type HttpRequestResponseCallbackHandler = ({
-  httpRequest: ModifiableHttpRequest,
-  httpResponse: ModifiableHttpResponse,
-}) => ModifiableHttpResponse; 
+export type ModifiableHttpResponseAndRequest = {
+  httpRequest: ModifiableHttpRequest;
+  httpResponse: ModifiableHttpResponse;
+};
+
+export type HttpRequestResponseCallbackHandler = (
+  requestAndResponse: ModifiableHttpResponseAndRequest
+) => ModifiableHttpResponse; 
 
 export interface MockServerClient {
     openAPIExpectation(expectation: OpenAPIExpectation): Promise<RequestResponse>;

--- a/mockServerClient.d.ts
+++ b/mockServerClient.d.ts
@@ -65,6 +65,16 @@ export interface MockServerClient {
     retrieveRecordedExpectations(pathOrRequestDefinition: PathOrRequestDefinition): Promise<Expectation[]>;
 
     retrieveLogMessages(pathOrRequestDefinition: PathOrRequestDefinition): Promise<string[]>;
+
+    forwardWithCallback(
+        requestMatcher: RequestDefinition, 
+        requestHandler: (request: HttpRequest) => HttpResponse, 
+        requestAndResponseHandler: (request: HttpRequestAndHttpResponse) => HttpResponse, 
+        times?: Times | number,
+        priority?: number,
+        timeToLive?: TimeToLive,
+        id?: string
+    ): Promise<RequestResponse>;
 }
 
 /**


### PR DESCRIPTION
I've created `forwardWithCallback()` in the style of `mockWithCallback()`, tried to make as minimal change as possible, could reuse some of the code in `createExpectationWithCallback` but opted to keep it all separate

The only difference in contract with `mockWithCallback()`  is the `requestAndResponseHandler`, which if present triggers `responseCallback: true`. Don't know if there are other scenarios other than replying an HttpRequest and then a HttpResponse to the websocket but I can implement them if needed

If approach is approved I can look into testing and later updating the docs for the javascript example