### PR TITLE
fix: fix clearById method signature #158

### DIFF
--- a/mockServerClient.d.ts
+++ b/mockServerClient.d.ts
@@ -52,7 +52,7 @@ export interface MockServerClient {
 
     clear(pathOrRequestDefinition: PathOrRequestDefinition, type: ClearType): Promise<RequestResponse>;
 
-    clearById(expectationId: ExpectationId, type: ClearType): Promise<RequestResponse>;
+    clearById(expectationId: string, type: ClearType): Promise<RequestResponse>;
 
     bind(ports: Port[]): Promise<RequestResponse>;
 


### PR DESCRIPTION
Hey,

I have the same problem as the author of #158 .
I've decided to fix the method signature in the type declaration and not touch the JS implementation for backward compatibility reasons. 

This decision was the most logical from my point of view, please tell me if I'm wrong, and I can change the PR.

Note: The signature of `clearById` will be inconsistent with the signature of `verifyById` if `clearById` only accepts a string. 
The signature of `verifyById`: `verifyById (ExpectationId, number, number)`.